### PR TITLE
Using PySerials inbuilt timeout functionality and formatting code the `pythonic` way

### DIFF
--- a/pycobolt/pycobolt/__init__.py
+++ b/pycobolt/pycobolt/__init__.py
@@ -1,1 +1,1 @@
-from  pycobolt.pycobolt import *
+from pycobolt.pycobolt import *

--- a/pycobolt/pycobolt/pycobolt.py
+++ b/pycobolt/pycobolt/pycobolt.py
@@ -22,12 +22,16 @@ class CoboltLaser:
 
     def __str__(self):
         try:
-            return f'Serial number: {self.serialnumber}, ' \
-                   f'Model number: {self.modelnumber}, ' \
-                   f'Wavelength: {self.modelnumber[0:4]:.0f} nm, ' \
-                   f'Type: {self.__class__.__name__}'
+            return (
+                f"Serial number: {self.serialnumber}, "
+                f"Model number: {self.modelnumber}, "
+                f"Wavelength: {self.modelnumber[0:4]:.0f} nm, "
+                f"Type: {self.__class__.__name__}"
+            )
         except TypeError:
-            return f"Serial number: {self.serialnumber}, Model number: {self.modelnumber}"
+            return (
+                f"Serial number: {self.serialnumber}, Model number: {self.modelnumber}"
+            )
 
     def connect(self):
         """
@@ -50,7 +54,9 @@ class CoboltLaser:
             ports = list_ports.comports()
             for port in ports:
                 try:
-                    self.address = serial.Serial(port.device, baudrate=self.baudrate, timeout=1)
+                    self.address = serial.Serial(
+                        port.device, baudrate=self.baudrate, timeout=1
+                    )
                     sn = self.send_cmd("sn?")
                     self.address.close()
                     if sn == self.serialnumber:
@@ -82,8 +88,10 @@ class CoboltLaser:
             self.serialnumber = self.send_cmd("sn?")
             if "." not in firmware:
                 if "0" in self.serialnumber:
-                    self.modelnumber = f"0{self.serialnumber.partition('0')[0]}-04-XX-XXXX-XXX"
-                    self.serialnumber = self.serialnumber.partition('0')[2].lstrip('0')
+                    self.modelnumber = (
+                        f"0{self.serialnumber.partition('0')[0]}-04-XX-XXXX-XXX"
+                    )
+                    self.serialnumber = self.serialnumber.partition("0")[2].lstrip("0")
             else:
                 self.modelnumber = self.send_cmd("glm?")
         except (RuntimeError, TypeError):
@@ -93,8 +101,11 @@ class CoboltLaser:
     def _classify_(self):
         """Classifies the laser into proper subclass depending on laser type"""
         try:
-            if "-71-" not in self.modelnumber and "-06-" in self.modelnumber and \
-                    ("-91-" in self.modelnumber[0:4] or "-93-" in self.modelnumber[0:4]):
+            if (
+                "-71-" not in self.modelnumber
+                and "-06-" in self.modelnumber
+                and ("-91-" in self.modelnumber[0:4] or "-93-" in self.modelnumber[0:4])
+            ):
                 self.__class__ = Cobolt06DPL
             else:
                 self.__class__ = Cobolt06MLD
@@ -292,7 +303,7 @@ class Cobolt06MLD(CoboltLaser):
 
     def on_off_modulation(self, enable):
         """Enable On/Off modulation mode by enable=1, turn off by enable=0"""
-        return self.send_cmd('eoom' if enable else 'xoom')
+        return self.send_cmd("eoom" if enable else "xoom")
 
     def get_modulation_state(self):
         """Get the laser modulation settings as [analog, digital]"""

--- a/pycobolt/pycobolt/pycobolt.py
+++ b/pycobolt/pycobolt/pycobolt.py
@@ -146,7 +146,7 @@ class CoboltLaser:
             "4": "4 - Constant power time out",
         }
         fault = self.send_cmd("f?")
-        return faults.get(fault)
+        return faults.get(fault, default=fault)
 
     def clear_fault(self):
         """Clear laser fault"""
@@ -160,7 +160,7 @@ class CoboltLaser:
             "2": "2 - Modulation Mode",
         }
         mode = self.send_cmd("gam?")
-        return modes.get(mode)
+        return modes.get(mode, default=mode)
 
     def get_state(self):
         """Get autostart state"""
@@ -174,7 +174,7 @@ class CoboltLaser:
             "6": "6 - Aborted",
         }
         state = self.send_cmd("gom?")
-        return states.get(state)
+        return states.get(state, default=state)
 
     def constant_current(self, current=None):
         """Enter constant current mode, current in mA"""


### PR DESCRIPTION
The PySerial package already has exceptions for timeouts. The function _timeDiff_ is redundant.

Fixed some python specific formatting:
- `not "pattern" in string` should be `"pattern" not in string`
- `var == None` should be `var is None`
- `dictionary.get(key, key)` should be `dictionary.get(key)`
- bare excepts are really broad and catch errors that should not be caught (like KeyboardInterrupt)
- max 120 character line length
- formatted strings should have placeholders
- using inbuilt python functions for str manipulation:
    - str.rstrip() removes trailing whitespace characters
    - str.lstrip('0') removes leading zeros
- fixed typos
- .py files should end on newline character
- nested try except blocks are redundant
